### PR TITLE
Bump Composition assembly & add ISuggestedActionCategoryRegistryServi…

### DIFF
--- a/Microsoft.VisualStudio.MiniEditor/BaseViewImpl/MockSuggestedActionCategoryRegistryService.cs
+++ b/Microsoft.VisualStudio.MiniEditor/BaseViewImpl/MockSuggestedActionCategoryRegistryService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Language.Intellisense;
+
+namespace Microsoft.VisualStudio.Language.Intellisense.Implementation
+{
+    [Export(typeof(ISuggestedActionCategoryRegistryService))]
+    sealed class MockSuggestedActionCategoryRegistryService : ISuggestedActionCategoryRegistryService
+    {
+        public IEnumerable<ISuggestedActionCategory> Categories => throw new NotImplementedException();
+
+        public ISuggestedActionCategorySet Any => throw new NotImplementedException();
+
+        public ISuggestedActionCategorySet AllCodeFixes => throw new NotImplementedException();
+
+        public ISuggestedActionCategorySet AllRefactorings => throw new NotImplementedException();
+
+        public ISuggestedActionCategorySet AllCodeFixesAndRefactorings => throw new NotImplementedException();
+
+        public ISuggestedActionCategorySet CreateSuggestedActionCategorySet(IEnumerable<string> categories)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ISuggestedActionCategorySet CreateSuggestedActionCategorySet(params string[] categories)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ISuggestedActionCategory GetCategory(string categoryName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Microsoft.VisualStudio.MiniEditor/Microsoft.VisualStudio.MiniEditor.csproj
+++ b/Microsoft.VisualStudio.MiniEditor/Microsoft.VisualStudio.MiniEditor.csproj
@@ -34,11 +34,12 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(VSEditorNugetVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(VSEditorNugetVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Language" Version="$(VSEditorNugetVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(VSEditorNugetVersion)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.20" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.2.51" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
   </ItemGroup>
 


### PR DESCRIPTION
…ce impl

Bumping Microsoft.VisualStudio.Composition was needed to
get our Android Designer unit tests to continue to work.

Adding MockSuggestedActionCategoryRegistryService helps
avoid a (benign) MEF error as we have some code that tries to import it,
though it's not actually used for test cases.